### PR TITLE
add support for custom projects filter

### DIFF
--- a/gcp/cost-guard/existing-project-onboarding/main.tf
+++ b/gcp/cost-guard/existing-project-onboarding/main.tf
@@ -1,5 +1,5 @@
 data "google_projects" "org_projects" {
-  filter="lifecycleState:ACTIVE"
+  filter = "${var.projects_filter}"
 }
 
 locals {

--- a/gcp/cost-guard/existing-project-onboarding/variables.tf
+++ b/gcp/cost-guard/existing-project-onboarding/variables.tf
@@ -19,3 +19,9 @@ variable "monitored_projects" {
   description =  "monitored projects to add to the scoping project"
   default     = []
 }
+
+variable "projects_filter" {
+  type        = string
+  description = "A string filter as defined in the GCP REST API"
+  default     = "lifecycleState:ACTIVE"
+}

--- a/gcp/cost-guard/new-project-onboarding/main.tf
+++ b/gcp/cost-guard/new-project-onboarding/main.tf
@@ -7,7 +7,7 @@ resource "random_string" "random_suffix_id" {
 }
 
 data "google_projects" "org_projects" {
-  filter="lifecycleState:ACTIVE"
+  filter = "${var.projects_filter}"
 }
 
 locals {

--- a/gcp/cost-guard/new-project-onboarding/variables.tf
+++ b/gcp/cost-guard/new-project-onboarding/variables.tf
@@ -26,3 +26,9 @@ variable "monitored_projects" {
   description = "Finout's (billing) service account"
   default     = []
 }
+
+variable "projects_filter" {
+  type        = string
+  description = "A string filter as defined in the GCP REST API"
+  default     = "lifecycleState:ACTIVE"
+}


### PR DESCRIPTION
Example to filter only active projects and projects where the project ID does not match `^sys-*`:

```sh
terraform plan -var='projects_filter="lifecycleState:ACTIVE AND projectId!~^sys-*"'
```

The equivalent `gcloud` command:

```sh
 gcloud projects list --filter='lifecycleState:active AND projectId!~^sys-*'
```